### PR TITLE
Renamed spring parent artifact to spring-jdk17.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.mongock</groupId>
         <artifactId>mongock</artifactId>
-        <version>5.1.6</version>
+        <version>5.2.1</version>
     </parent>
 
     <artifactId>mongock-jdk17-parent</artifactId>
-    <version>5.2.0-SNAPSHOT</version>
+    <version>5.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>
@@ -19,9 +19,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 
-        <mongock.community.version>5.1.6</mongock.community.version>
-
-
+        <mongock.community.version>5.2.1</mongock.community.version>
     </properties>
 
     <modules>

--- a/spring/mongock-springboot-v3/pom.xml
+++ b/spring/mongock-springboot-v3/pom.xml
@@ -6,8 +6,8 @@
 
     <parent>
         <groupId>io.mongock</groupId>
-        <artifactId>spring</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <artifactId>spring-jdk17</artifactId>
+        <version>5.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mongock-springboot-v3</artifactId>

--- a/spring/mongodb-springdata-v4-driver/pom.xml
+++ b/spring/mongodb-springdata-v4-driver/pom.xml
@@ -6,8 +6,8 @@
 
     <parent>
         <groupId>io.mongock</groupId>
-        <artifactId>spring</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <artifactId>spring-jdk17</artifactId>
+        <version>5.2.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>mongodb-springdata-v4-driver</artifactId>
@@ -96,7 +96,7 @@
             <artifactId>mongodb-sync-v4-driver</artifactId>
             <classifier>tests</classifier>
             <type>test-jar</type>
-            <version>5.1.6</version>
+            <version>${mongock.community.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -105,6 +105,12 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+             <version>${mockito-core.version}</version>
+            <scope>test</scope>
+          </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -7,10 +7,10 @@
     <parent>
         <groupId>io.mongock</groupId>
         <artifactId>mongock-jdk17-parent</artifactId>
-        <version>5.2.0-SNAPSHOT</version>
+        <version>5.2.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>spring</artifactId>
+    <artifactId>spring-jdk17</artifactId>
     <packaging>pom</packaging>
     <properties>
         <springframework-6.version>[6.0.0-RC2, 7.0.0)</springframework-6.version>


### PR DESCRIPTION
Renamed spring parent artifact to spring-jdk17. Updated community version. Release 5.2.1.